### PR TITLE
Update swift-syntax version constraint to range 600.0.0..<603.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "35c6fb584459da4fe3f1d7ef67352a2cab82d35ffcae369c27dea786a3352426",
+  "originHash" : "dd86d2493cca1545a2dbd5638765bbeb508b3186ba9725c496b8ec29519e9380",
   "pins" : [
     {
       "identity" : "swift-collections",
@@ -11,12 +11,21 @@
       }
     },
     {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
       "identity" : "swift-macro-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing.git",
       "state" : {
-        "revision" : "20c1a8f3b624fb5d1503eadcaa84743050c350f4",
-        "version" : "0.5.2"
+        "revision" : "9ab11325daa51c7c5c10fcf16c92bac906717c7e",
+        "version" : "0.6.4"
       }
     },
     {
@@ -24,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "42a086182681cf661f5c47c9b7dc3931de18c6d7",
-        "version" : "1.17.6"
+        "revision" : "a8b7c5e0ed33d8ab8887d1654d9b59f2cbad529b",
+        "version" : "1.18.7"
       }
     },
     {
@@ -33,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {
@@ -53,6 +62,15 @@
       "state" : {
         "revision" : "337ce0e573e7637ddd29392cb88c3b852f042c8e",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "b2ed9eabefe56202ee4939dd9fc46b6241c88317",
+        "version" : "1.6.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
     .package(url: "https://github.com/VergeGroup/TypedComparator", from: "1.0.0"),
     .package(url: "https://github.com/VergeGroup/swift-typed-identifier", from: "2.0.4"),
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "600.0.0"),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: "602.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.2.1"),
   ],
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
     .package(url: "https://github.com/VergeGroup/TypedComparator", from: "1.0.0"),
     .package(url: "https://github.com/VergeGroup/swift-typed-identifier", from: "2.0.4"),
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "602.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"603.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.2.1"),
   ],
   targets: [


### PR DESCRIPTION
## Summary
Update swift-syntax dependency version constraint from `from: "602.0.0"` to range `"600.0.0"..<"603.0.0"`.

Also update URL from deprecated `apple/swift-syntax` to the new `swiftlang/swift-syntax`.

## Changes
- Modified Package.swift to use version range instead of minimum version constraint
- Updated repository URL to the official Swift.org repository
- This allows compatibility with swift-syntax versions 600.0.0 through 602.x.x while excluding 603.0.0+

## Motivation
Range-based version constraints provide better compatibility and prevent potential breaking changes from newer major versions while maintaining support for a broader range of compatible versions.

## Testing
- [x] Package builds successfully with the new version constraint
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)